### PR TITLE
Restaure "docker compose up -d" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ services:
 
 Please remember to create an empty folder where the keys can be stored later. In this example, it is `~/TeslaBleHttpProxy/key`.
 
+Pull and start TeslaBleHttpProxy with `docker compose up -d`
+
 ### Build yourself
 
 Download the code and save it in a folder named 'TeslaBleHttpProxy'. From there, you can easily compile the program.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ services:
 
 Please remember to create an empty folder where the keys can be stored later. In this example, it is `~/TeslaBleHttpProxy/key`.
 
-Pull and start TeslaBleHttpProxy with `docker compose up -d`
+Pull and start TeslaBleHttpProxy with `docker compose up -d`.
 
 ### Build yourself
 


### PR DESCRIPTION
I think the README has been over simplified and does not say anything anymore about going from the `docker-compose.yml` (why yml and not yaml ?) to a running container. Most people will know or find-out, but it can be spelled out for the other.