### PR TITLE
Add support for "charge_port_door_open" and "charge_port_door_close"

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -273,6 +273,14 @@ func (bc *BleControl) executeCommand(car *vehicle.Vehicle, command *Command) (*C
 
 func (bc *BleControl) sendCommand(ctx context.Context, car *vehicle.Vehicle, command *Command) (bool, error) {
 	switch command.Command {
+	case "charge_port_door_open":
+		if err := car.ChargePortOpen(ctx); err != nil {
+			return true, fmt.Errorf("failed to open charge port: %s", err)
+		}
+	case "charge_port_door_close":
+		if err := car.ChargePortClose(ctx); err != nil {
+			return true, fmt.Errorf("failed to close charge port: %s", err)
+		}
 	case "flash_lights":
 		if err := car.FlashLights(ctx); err != nil {
 			return true, fmt.Errorf("failed to flash lights: %s", err)

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ type Response struct {
 	Command string `json:"command"`
 }
 
-var exceptedCommands = []string{"flash_lights", "wake_up", "set_charging_amps", "set_charge_limit", "charge_start", "charge_stop", "session_info"}
+var exceptedCommands = []string{"charge_port_door_open", "charge_port_door_close", "flash_lights", "wake_up", "set_charging_amps", "set_charge_limit", "charge_start", "charge_stop", "session_info"}
 
 //go:embed static/*
 var static embed.FS


### PR DESCRIPTION
Allow opening and closing of the charge port. Command "charge_port_door_open" stops charging and unlocks charge port so you can plug out the charging cable. "charge_port_door_close" simply closes the charge port if no cable is plugged in.

I tested it locally and it worked.