### PR TITLE
Allow passing in addr for http proxy to listen on

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,4 +14,5 @@ services:
       - SYS_ADMIN
     environment: #optional
       logLevel: debug
+      httpListenAddress: :8080
       

--- a/main.go
+++ b/main.go
@@ -43,6 +43,12 @@ func main() {
 		ble.SetDebugLog()
 	}
 
+	addr := os.Getenv("httpListenAddress")
+	if addr == "" {
+		addr = ":8080"
+	}
+	log.Info("TeslaBleHttpProxy", "httpListenAddress", addr)
+
 	control.SetupBleControl()
 
 	router := mux.NewRouter()
@@ -57,7 +63,7 @@ func main() {
 	router.PathPrefix("/static/").Handler(http.FileServer(http.FS(static)))
 
 	log.Info("TeslaBleHttpProxy is running!")
-	log.Fatal(http.ListenAndServe(":8080", router))
+	log.Fatal(http.ListenAndServe(addr, router))
 }
 
 /*func testR(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
To allow restricting access to the http proxy, read an optional addr (`host:port`) from an environment variable (`httpListenAddress`). This also allows setting it in `docker-compose.yml`

For example, this runs the proxy server on `127.0.0.1:8080`:
```
httpListenAddress="127.0.0.1:8080" ./TeslaBleHttpProxy
```