### PR TITLE
fix ARMv6 build with goarm=

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,12 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
+ARG TARGETVARIANT
+ARG GOARM=${TARGETVARIANT#v}
 
 #WORKDIR /app/
 #ADD . .
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-w -s" -o /go/bin/teslaBleHttpProxy main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${GOARM} go build -ldflags="-w -s" -o /go/bin/teslaBleHttpProxy main.go
 RUN mkdir -p /go/bin/key
 
 FROM scratch


### PR DESCRIPTION
Tested a local built docker image and it works on ARMv6

build command I used was: docker buildx build . --platform linux/arm/v6 -t teslablehttpproxymine:1.0