### PR TITLE
Fix Bug with ConnectionCtx

### DIFF
--- a/internal/ble/control/control.go
+++ b/internal/ble/control/control.go
@@ -371,9 +371,11 @@ func (bc *BleControl) ExecuteCommand(car *vehicle.Vehicle, command *commands.Com
 	// Wrap ctx with connectionCtx
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+	connectionCtxDone := false
 	go func() {
 		select {
 		case <-connectionCtx.Done():
+			connectionCtxDone = true
 			cancel()
 		case <-ctx.Done():
 		}
@@ -386,6 +388,9 @@ func (bc *BleControl) ExecuteCommand(car *vehicle.Vehicle, command *commands.Com
 			select {
 			case <-time.After(sleep):
 			case <-ctx.Done():
+				if connectionCtxDone {
+					return command, ctx.Err(), ctx
+				}
 				return nil, ctx.Err(), ctx
 			}
 			sleep *= 2

--- a/internal/tesla/commands/commands.go
+++ b/internal/tesla/commands/commands.go
@@ -166,7 +166,7 @@ func (command *Command) Send(ctx context.Context, car *vehicle.Vehicle) (shouldR
 			log.Debugf("get: %s", endpoint)
 			category, err := GetCategory(endpoint)
 			if err != nil {
-				return false, fmt.Errorf("unrecognized state category charge")
+				return false, err
 			}
 			data, err := car.GetState(ctx, category)
 			if err != nil {


### PR DESCRIPTION
If an HTTP request was received just before the timeout (29 seconds), the request was aborted and not retried. Now, this request is being correctly retried.