### PR TITLE
Add Version API Endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ TAG_NAME := $(shell test -d .git && git describe --abbrev=0 --tags)
 SHA := $(shell test -d .git && git rev-parse --short HEAD)
 VERSION := $(if $(TAG_NAME),$(TAG_NAME),$(SHA))
 
-LD_FLAGS := -X main.Version=$(VERSION) -s -w
+LD_FLAGS := -X github.com/wimaha/TeslaBleHttpProxy/config.Version=$(VERSION) -s -w
 BUILD_ARGS := -ldflags='$(LD_FLAGS)'
 BUILD_DATE := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The program stores the received requests in a queue and processes them one by on
   - [Vehicle Commands](#vehicle-commands)
   - [Vehicle Data](#vehicle-data)
   - [Body Controller State](#body-controller-state)
+  - [Version of Proxy](#version-of-proxy)
 - [Vehicle and Connection Requirements](#vehicle-and-connection-requirements)
 
 ## How to install
@@ -200,6 +201,13 @@ The body controller state is fetched from the vehicle and returnes the state of 
 
 Get body controller state:
 `http://localhost:8080/api/1/vehicles/{VIN}/body_controller_state`
+
+### Version of Proxy
+
+Get version of proxy:
+`http://localhost:8080/api/proxy/1/version`
+
+The response will contain the version of the proxy.
 
 ## Vehicle and Connection Requirements
 

--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,9 @@ import (
 var PublicKeyFile = "key/public.pem"
 var PrivateKeyFile = "key/private.pem"
 
+// Version is set at build time via linker flags
+var Version = "*undefined*"
+
 type Config struct {
 	LogLevel          string
 	HttpListenAddress string

--- a/html/dashboard.html
+++ b/html/dashboard.html
@@ -67,4 +67,7 @@
         <button id="save-button" class="add-button" type="submit">Send Key to Vehicle</button>
     </form>
 </div>
+<div class="footer">
+    <span class="version">Version {{.Version}}</span>
+</div>
 {{end}}

--- a/internal/api/handlers/html.go
+++ b/internal/api/handlers/html.go
@@ -19,6 +19,7 @@ type DashboardParams struct {
 	PublicKey     string
 	ShouldGenKeys bool
 	Messages      []models.Message
+	Version       string
 }
 
 func ShowDashboard(html fs.FS) http.HandlerFunc {
@@ -43,6 +44,7 @@ func ShowDashboard(html fs.FS) http.HandlerFunc {
 			PublicKey:     publicKey,
 			ShouldGenKeys: shouldGenKeys,
 			Messages:      messages,
+			Version:       config.Version,
 		}
 		if err := Dashboard(w, p, "", html); err != nil {
 			log.Error("Error showing dashboard", "Error", err)

--- a/internal/api/handlers/version.go
+++ b/internal/api/handlers/version.go
@@ -1,0 +1,28 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/wimaha/TeslaBleHttpProxy/config"
+	"github.com/wimaha/TeslaBleHttpProxy/internal/api/models"
+)
+
+func Version(w http.ResponseWriter, r *http.Request) {
+	versionData := map[string]string{
+		"version": config.Version,
+	}
+
+	versionJson, _ := json.Marshal(versionData)
+
+	response := models.Ret{
+		Response: models.Response{
+			Result:   true,
+			Reason:   "The request was successfully processed.",
+			Response: versionJson,
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+}

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -16,6 +16,7 @@ func SetupRoutes(static embed.FS, html embed.FS) *mux.Router {
 	router.HandleFunc("/api/1/vehicles/{vin}/command/{command}", handlers.Command).Methods("POST")
 	router.HandleFunc("/api/1/vehicles/{vin}/vehicle_data", handlers.VehicleData).Methods("GET")
 	router.HandleFunc("/api/1/vehicles/{vin}/body_controller_state", handlers.BodyControllerState).Methods("GET")
+	router.HandleFunc("/api/proxy/1/version", handlers.Version).Methods("GET")
 	router.HandleFunc("/dashboard", handlers.ShowDashboard(html)).Methods("GET")
 	router.HandleFunc("/gen_keys", handlers.GenKeys).Methods("GET")
 	router.HandleFunc("/remove_keys", handlers.RemoveKeys).Methods("GET")

--- a/main.go
+++ b/main.go
@@ -16,10 +16,8 @@ var static embed.FS
 //go:embed html/*
 var html embed.FS
 
-var Version = "*undefined*"
-
 func main() {
-	log.Infof("TeslaBleHttpProxy %s is loading ...", Version)
+	log.Infof("TeslaBleHttpProxy %s is loading ...", config.Version)
 
 	config.InitConfig()
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -25,6 +25,18 @@ h1 {
     font-size: 24px;
 }
 
+.version {
+    font-size: 12px;
+    color: #666;
+    font-weight: normal;
+}
+
+.footer {
+    text-align: center;
+    margin-top: 20px;
+    margin-bottom: 20px;
+}
+
 .settings-list {
     list-style-type: none;
     padding: 0;


### PR DESCRIPTION
# Add Version API Endpoint

## Description
This PR adds a new API endpoint to retrieve the current version of the TeslaBleHttpProxy. The version information is set at build time via linker flags and is also being shown in the dashboard UI.

(Request see https://github.com/wimaha/TeslaBleHttpProxy/discussions/118)

## Changes
- Added new version handler in `internal/api/handlers/version.go`
- Added new API endpoint `/api/proxy/1/version` in `internal/api/routes/routes.go`
- Follows existing API response format for consistency

## API Response Format
```json
{
    "response": {
        "result": true,
        "reason": "success",
        "response": {
            "version": "1.0.0"  // Set at build time via linker flags
        }
    }
}
```

## Testing
The endpoint can be tested with:
```bash
curl http://localhost:8080/api/proxy/1/version
```

## Notes
- The version is automatically set during the build process using git tags or commit hashes
- For development builds, it shows the git commit hash
- For release builds, it shows the git tag version
- The endpoint follows the proxy-specific API path pattern `/api/proxy/1/` to distinguish it from vehicle-related endpoints