### PR TITLE
invalid go version '1.24.3': must match format 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wimaha/TeslaBleHttpProxy
 
-go 1.24.3
+go 1.24
 
 require (
 	github.com/charmbracelet/log v0.4.0


### PR DESCRIPTION
You need this when you build by yourself https://github.com/wimaha/TeslaBleHttpProxy/tree/main?tab=readme-ov-file#build-yourself