### PR TITLE
Allow retry on BLE scan timeout in TryConnectToVehicle

### DIFF
--- a/internal/ble/control/control.go
+++ b/internal/ble/control/control.go
@@ -238,7 +238,8 @@ func (bc *BleControl) TryConnectToVehicle(ctx context.Context, firstCommand *com
 	scanResult, err := ble.ScanVehicleBeacon(scanCtx, firstCommand.Vin)
 	if err != nil {
 		if scanCtx.Err() != nil {
-			return nil, nil, false, fmt.Errorf("Vehicle is not in range: %s", err)
+			// Scan timed out - allow retry as vehicle might be temporarily out of range or experiencing transient BLE issues
+			return nil, nil, true, fmt.Errorf("Vehicle is not in range: %s", err)
 		} else {
 			if strings.Contains(err.Error(), "operation not permitted") {
 				// The underlying BLE package calls HCIDEVDOWN on the BLE device, presumably as a


### PR DESCRIPTION
Modified TryConnectToVehicle to return a retryable flag when BLE scan times out, indicating that the vehicle may be temporarily out of range or experiencing transient BLE issues.