### PR TITLE
Default key role to charging_manager for improved security

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -44,8 +44,8 @@ func getActiveKeyRole() string {
 		return "owner"
 	}
 
-	// Default to owner if no keys exist
-	return "owner"
+	// Default to charging_manager if no keys exist (recommended for security)
+	return "charging_manager"
 }
 
 // getKeyFilesForRole returns key file paths for a given role
@@ -62,15 +62,15 @@ func getKeyFilesForRole(role string) (string, string) {
 			}
 			return "key/private.pem", "key/public.pem"
 		}
-		// Default to owner if no legacy keys
-		role = "owner"
+		// Default to charging_manager if no legacy keys (recommended for security)
+		role = "charging_manager"
 	}
 
 	// Validate role contains only safe characters (basic check)
 	// Full validation should be done by ValidateRole in control package
 	if strings.Contains(role, "..") || strings.Contains(role, "/") || strings.Contains(role, "\\") {
-		// Path traversal attempt detected, default to owner
-		role = "owner"
+		// Path traversal attempt detected, default to charging_manager
+		role = "charging_manager"
 	}
 
 	// New role-based key structure - use filepath.Join for safety

--- a/html/dashboard.html
+++ b/html/dashboard.html
@@ -60,8 +60,8 @@
     <div class="add-setting key-roles-info">
         <h4>Key Roles Explained:</h4>
         <ul class="role-list">
-            <li><strong>Owner:</strong> Full access to all vehicle functions (unlock, start, charge, etc.)</li>
-            <li><strong>Charging Manager:</strong> Limited to charging-related functions only (start/stop charging, set charging amps, etc.)</li>
+            <li><strong>Charging Manager (Recommended):</strong> Secure, limited access for charging management. Can read vehicle data and authorize charging-related commands: wake, charge_start, charge_stop, set_charging_amps. Perfect for use with <a href="https://docs.evcc.io/docs/devices/vehicles#tesla-ble" target="_blank">evcc tesla-ble template</a>.</li>
+            <li><strong>Owner:</strong> Full access to all vehicle functions (unlock, start, charge, etc.). Use only if you need non-charging functions.</li>
         </ul>
         <div class="migration-note" style="margin-top: 12px; padding-top: 12px; border-top: 1px solid #dee2e6; font-size: 13px; color: #666; line-height: 1.6;">
             <strong>Note:</strong> If you had keys from a previous version, they were automatically migrated to the Owner role on startup.

--- a/internal/api/handlers/html.go
+++ b/internal/api/handlers/html.go
@@ -35,7 +35,8 @@ func ShowDashboard(html fs.FS) http.HandlerFunc {
 		activeRole := control.GetActiveKeyRole()
 
 		// Build key info list (exclude legacy - it's automatically migrated)
-		allRoles := []string{control.KeyRoleOwner, control.KeyRoleChargingManager}
+		// Charging Manager first as it's recommended for security
+		allRoles := []string{control.KeyRoleChargingManager, control.KeyRoleOwner}
 		keys := make([]KeyInfo, 0)
 
 		for _, role := range allRoles {
@@ -68,7 +69,7 @@ func GenKeys(w http.ResponseWriter, r *http.Request) {
 	// Get role from query parameter
 	role := r.URL.Query().Get("role")
 	if role == "" {
-		role = control.KeyRoleOwner // Default to owner
+		role = control.KeyRoleChargingManager // Default to charging_manager (recommended for security)
 	}
 
 	// Validate role to prevent path traversal
@@ -174,9 +175,9 @@ func RemoveKeys(w http.ResponseWriter, r *http.Request) {
 						break
 					}
 				}
-				// Fallback to owner if no valid role found
+				// Fallback to charging_manager if no valid role found (recommended for security)
 				if newActiveRole == "" {
-					newActiveRole = control.KeyRoleOwner
+					newActiveRole = control.KeyRoleChargingManager
 				}
 				if err := control.SetActiveKeyRole(newActiveRole); err == nil {
 					models.MainMessageStack.Push(models.Message{
@@ -250,7 +251,8 @@ func SendKey(w http.ResponseWriter, r *http.Request) {
 			activeRole := control.GetActiveKeyRole()
 			// Ensure active role is not legacy (should have been migrated)
 			if activeRole == "" {
-				activeRole = control.KeyRoleOwner
+				// Default to charging_manager (recommended for security)
+				activeRole = control.KeyRoleChargingManager
 			}
 			role = activeRole
 		}

--- a/internal/ble/control/key.go
+++ b/internal/ble/control/key.go
@@ -18,8 +18,8 @@ import (
 )
 
 func CreatePrivateAndPublicKeyFile() error {
-	// Default to owner role for backward compatibility
-	return CreatePrivateAndPublicKeyFileForRole(KeyRoleOwner)
+	// Default to charging_manager role (recommended for security)
+	return CreatePrivateAndPublicKeyFileForRole(KeyRoleChargingManager)
 }
 
 func CreatePrivateAndPublicKeyFileForRole(role string) error {

--- a/internal/ble/control/keymanager.go
+++ b/internal/ble/control/keymanager.go
@@ -74,16 +74,16 @@ func GetKeyFiles(role string) (privateKeyFile, publicKeyFile string) {
 			}
 			return "key/private.pem", "key/public.pem"
 		}
-		// Default to owner if no legacy keys
-		role = KeyRoleOwner
+		// Default to charging_manager if no legacy keys (recommended for security)
+		role = KeyRoleChargingManager
 	}
 
 	// Validate role to prevent path traversal
 	validatedRole, err := ValidateRole(role)
 	if err != nil {
-		// If validation fails, default to owner and log warning
-		logging.Warn("Invalid role provided, defaulting to owner", "role", role, "error", err)
-		validatedRole = KeyRoleOwner
+		// If validation fails, default to charging_manager and log warning
+		logging.Warn("Invalid role provided, defaulting to charging_manager", "role", role, "error", err)
+		validatedRole = KeyRoleChargingManager
 	}
 
 	// Build paths using filepath.Join for safety
@@ -99,8 +99,8 @@ func GetKeyFiles(role string) (privateKeyFile, publicKeyFile string) {
 		if err == nil {
 			relPath, err := filepath.Rel(absKeyDir, absPrivateKey)
 			if err != nil || strings.HasPrefix(relPath, "..") {
-				logging.Error("Path traversal detected, using default owner role", "role", role, "path", privateKeyFile)
-				keyDir = filepath.Join("key", KeyRoleOwner)
+				logging.Error("Path traversal detected, using default charging_manager role", "role", role, "path", privateKeyFile)
+				keyDir = filepath.Join("key", KeyRoleChargingManager)
 				privateKeyFile = filepath.Join(keyDir, "private.pem")
 				publicKeyFile = filepath.Join(keyDir, "public.pem")
 			}
@@ -134,8 +134,8 @@ func GetActiveKeyRole() string {
 		return KeyRoleOwner
 	}
 
-	// Default to owner if no keys exist
-	return KeyRoleOwner
+	// Default to charging_manager if no keys exist (recommended for security)
+	return KeyRoleChargingManager
 }
 
 // SetActiveKeyRole sets the active key role

--- a/internal/tesla/commands/commands.go
+++ b/internal/tesla/commands/commands.go
@@ -144,8 +144,8 @@ func (command *Command) Send(ctx context.Context, car *vehicle.Vehicle) (shouldR
 		}
 		fmt.Printf("%s\n", info)
 	case "add-key-request":
-		// Get role from command body, default to owner
-		roleStr := "owner"
+		// Get role from command body, default to charging_manager (recommended for security)
+		roleStr := "charging_manager"
 		if command.Body != nil {
 			if role, ok := command.Body["role"].(string); ok && role != "" {
 				roleStr = role
@@ -185,8 +185,8 @@ func (command *Command) Send(ctx context.Context, car *vehicle.Vehicle) (shouldR
 		case "charging_manager":
 			keyRole = keys.Role_ROLE_CHARGING_MANAGER
 		default:
-			// Default to owner for backward compatibility
-			keyRole = keys.Role_ROLE_OWNER
+			// Default to charging_manager (recommended for security)
+			keyRole = keys.Role_ROLE_CHARGING_MANAGER
 		}
 
 		// Get display name for logging

--- a/main.go
+++ b/main.go
@@ -32,6 +32,18 @@ func main() {
 
 	control.SetupBleControl()
 
+	// Warn if Owner role is active (Charging Manager is recommended for security)
+	activeRole := control.GetActiveKeyRole()
+	if activeRole == control.KeyRoleOwner {
+		logging.Warn(
+			"⚠️  SECURITY WARNING: Owner role is currently active. " +
+				"Owner role provides full access to all vehicle functions (unlock, start, etc.). " +
+				"For better security, consider using the Charging Manager role instead, which provides " +
+				"limited access suitable for charging management and works perfectly with evcc tesla-ble template. " +
+				"You can switch roles in the dashboard.",
+		)
+	}
+
 	router := routes.SetupRoutes(static, html)
 
 	logging.Info("TeslaBleHttpProxy is running!")


### PR DESCRIPTION
Changed the default key role from 'owner' to 'charging_manager' throughout the codebase to enhance security. Updated UI and documentation to recommend Charging Manager as the default, reordered role display, and added a warning if Owner role is active. This limits default access to charging-related functions and encourages best practices for deployments.