### PR TITLE
feat(api): add Raspberry reboot endpoint and logs UI action

### DIFF
--- a/html/logs.html
+++ b/html/logs.html
@@ -29,6 +29,7 @@
             
             <button id="refreshBtn" class="save-button small-button" style="margin-left: 15px;">Refresh</button>
             <button id="clearBtn" class="remove-button small-button">Clear Display</button>
+            <button id="rebootBtn" class="remove-button small-button" title="Reboot the Raspberry Pi">Reboot Raspberry</button>
             
             <label for="intervalSelect" style="font-weight: bold; margin-left: 15px;">Refresh Interval:</label>
             <select id="intervalSelect" style="padding: 5px; border: 1px solid #ccc; border-radius: 4px;">
@@ -242,6 +243,46 @@ document.getElementById('refreshBtn').addEventListener('click', () => {
 
 document.getElementById('clearBtn').addEventListener('click', () => {
     document.getElementById('logContainer').innerHTML = '<div style="color: #888;">Logs cleared.</div>';
+});
+
+document.getElementById('rebootBtn').addEventListener('click', async () => {
+    const firstConfirm = confirm('Are you sure you want to reboot the Raspberry Pi? The proxy will be temporarily unavailable.');
+    if (!firstConfirm) {
+        return;
+    }
+
+    const secondConfirm = confirm('Confirm reboot now?');
+    if (!secondConfirm) {
+        return;
+    }
+
+    const rebootBtn = document.getElementById('rebootBtn');
+    rebootBtn.disabled = true;
+    rebootBtn.textContent = 'Rebooting...';
+
+    try {
+        const response = await fetch('/api/admin/reboot', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: '{}'
+        });
+
+        const payload = await response.json();
+        if (response.ok && payload.response && payload.response.result) {
+            alert('Reboot initiated. The device should restart shortly.');
+            return;
+        }
+
+        const reason = payload && payload.response ? payload.response.reason : 'Unknown error';
+        alert(`Reboot failed: ${reason}`);
+    } catch (error) {
+        alert(`Reboot failed: ${error.message}`);
+    }
+
+    rebootBtn.disabled = false;
+    rebootBtn.textContent = 'Reboot Raspberry';
 });
 
 document.getElementById('liveModeCheckbox').addEventListener('change', toggleLiveMode);

--- a/html/logs.html
+++ b/html/logs.html
@@ -279,10 +279,10 @@ document.getElementById('rebootBtn').addEventListener('click', async () => {
         alert(`Reboot failed: ${reason}`);
     } catch (error) {
         alert(`Reboot failed: ${error.message}`);
+    } finally {
+        rebootBtn.disabled = false;
+        rebootBtn.textContent = 'Reboot Raspberry';
     }
-
-    rebootBtn.disabled = false;
-    rebootBtn.textContent = 'Reboot Raspberry';
 });
 
 document.getElementById('liveModeCheckbox').addEventListener('change', toggleLiveMode);

--- a/internal/api/handlers/logs.go
+++ b/internal/api/handlers/logs.go
@@ -1,13 +1,17 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"io/fs"
 	"net/http"
+	"os/exec"
 	"strconv"
 	"text/template"
 	"time"
 
+	"github.com/wimaha/TeslaBleHttpProxy/internal/api/models"
 	"github.com/wimaha/TeslaBleHttpProxy/internal/logging"
 )
 
@@ -75,4 +79,49 @@ func LogViewer(w http.ResponseWriter, html fs.FS) error {
 	tmpl := template.Must(
 		template.New("html/layout.html").ParseFS(html, "html/layout.html", "html/logs.html"))
 	return tmpl.ExecuteTemplate(w, "layout.html", nil)
+}
+
+// RebootSystem initiates a Raspberry Pi reboot.
+// The reboot is executed asynchronously so the API can return first.
+func RebootSystem(w http.ResponseWriter, r *http.Request) {
+	var response models.Response
+	response.Command = "system_reboot"
+	response.Result = false
+
+	defer commonDefer(w, &response)
+
+	logging.Warn("System reboot requested", "remote_addr", r.RemoteAddr)
+
+	go func() {
+		// Give the HTTP response time to flush before rebooting the host.
+		time.Sleep(750 * time.Millisecond)
+		if err := executeReboot(); err != nil {
+			logging.Error("Failed to execute reboot command", "error", err)
+		}
+	}()
+
+	response.Result = true
+	response.Reason = "System reboot initiated. The device will restart shortly."
+}
+
+func executeReboot() error {
+	commands := [][]string{
+		{"sudo", "shutdown", "-r", "now"},
+		{"/sbin/shutdown", "-r", "now"},
+		{"shutdown", "-r", "now"},
+	}
+
+	var lastErr error
+	for _, args := range commands {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+		err := cmd.Run()
+		cancel()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+	}
+
+	return fmt.Errorf("all reboot commands failed: %w", lastErr)
 }

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -21,6 +21,7 @@ func SetupRoutes(static embed.FS, html embed.FS) *mux.Router {
 	router.HandleFunc("/logs", handlers.ShowLogViewer(html)).Methods("GET")
 	router.HandleFunc("/api/logs", handlers.GetLogs).Methods("GET")
 	router.HandleFunc("/api/logs/stats", handlers.GetLogStats).Methods("GET")
+	router.HandleFunc("/api/admin/reboot", handlers.RebootSystem).Methods("POST")
 	router.HandleFunc("/gen_keys", handlers.GenKeys).Methods("GET")
 	router.HandleFunc("/remove_keys", handlers.RemoveKeys).Methods("GET")
 	router.HandleFunc("/activate_key", handlers.ActivateKey).Methods("POST")


### PR DESCRIPTION
## Summary
This PR adds a dedicated admin API endpoint to reboot the Raspberry Pi and integrates a reboot action in the logs page UI.

## Changes
- Add new route:
  - `POST /api/admin/reboot`
- Add backend handler:
  - `RebootSystem` in `internal/api/handlers/logs.go`
  - Executes reboot asynchronously after returning HTTP response
  - Tries commands in order:
    - `sudo shutdown -r now`
    - `/sbin/shutdown -r now`
    - `shutdown -r now`
- Add frontend action in logs page:
  - New button `Reboot Raspberry` in `html/logs.html`
  - Double confirmation prompt
  - Calls `/api/admin/reboot` via `fetch`
  - Disables button while request is in progress and reports result

## Why
Operators can now reboot the device directly from the web UI without SSH access.

## Validation
- `go test ./internal/api/...` passed

## Notes
- Reboot command requires appropriate OS permissions (`sudoers`/service user capabilities).