### PR TITLE
Release BLE adapter when idle; make connection hold configurable (connectionTimeout)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -92,6 +92,7 @@ type Config struct {
 	ScanTimeout          int // Seconds to scan for BLE devices
 	CacheMaxAge          int // Seconds for HTTP Cache-Control header max-age (used for body controller state responses). If set to 0, cache headers are disabled.
 	VehicleDataCacheTime int // Seconds to cache VehicleData endpoint responses in memory. Each endpoint is cached separately per VIN.
+	ConnectionTimeout    int // Seconds to keep the BLE connection open after a command before releasing the adapter to BlueZ. Lower = share adapter sooner; higher = batch follow-up commands.
 }
 
 var AppConfig *Config
@@ -145,12 +146,24 @@ func LoadConfig() *Config {
 	}
 	logging.Info("Env:", "vehicleDataCacheTime", vehicleDataCacheTimeInt)
 
+	connectionTimeout := os.Getenv("connectionTimeout")
+	if connectionTimeout == "" {
+		connectionTimeout = "10" // default value: 10 seconds
+	}
+	connectionTimeoutInt, err := strconv.Atoi(connectionTimeout)
+	if err != nil {
+		logging.Error("Invalid connectionTimeout value, using default (10)", "error", err)
+		connectionTimeoutInt = 10
+	}
+	logging.Info("Env:", "connectionTimeout", connectionTimeoutInt)
+
 	return &Config{
 		LogLevel:             envLogLevel,
 		HttpListenAddress:    addr,
 		CacheMaxAge:          cacheMaxAgeInt,
 		ScanTimeout:          scanTimeoutInt,
 		VehicleDataCacheTime: vehicleDataCacheTimeInt,
+		ConnectionTimeout:    connectionTimeoutInt,
 	}
 }
 

--- a/internal/ble/control/control.go
+++ b/internal/ble/control/control.go
@@ -75,6 +75,11 @@ func (bc *BleControl) Loop() {
 			logging.Info("Retrying command", "Command", retryCommand.Command, "Body", retryCommand.Body)
 			retryCommand = bc.connectToVehicleAndOperateConnection(retryCommand)
 		} else {
+			// No pending retry: release the BLE adapter back to BlueZ while idle
+			// so BlueZ D-Bus and other tools can use it between command sessions.
+			if err := ble.CloseAdapter(); err != nil {
+				logging.Debug("Failed to release BLE adapter", "error", err)
+			}
 			logging.Debug("Waiting for next command ...")
 			// Wait for the next command
 			select {
@@ -403,7 +408,7 @@ func (bc *BleControl) TryConnectToVehicle(ctx context.Context, firstCommand *com
 func (bc *BleControl) operateConnection(car *vehicle.Vehicle, firstCommand *commands.Command) *commands.Command {
 	logging.Debug("Operating connection ...")
 	//defer log.Debug("operating connection done")
-	connectionCtx, cancel := context.WithTimeout(context.Background(), 29*time.Second)
+	connectionCtx, cancel := context.WithTimeout(context.Background(), time.Duration(config.AppConfig.ConnectionTimeout)*time.Second)
 	defer cancel()
 
 	cmd, err, _ := bc.ExecuteCommand(car, firstCommand, connectionCtx)


### PR DESCRIPTION
Addresses #158 (adapter is not shared / stays claimed).

**Two changes:**

1. **Release the adapter when idle.** `BleControl.Loop()` now calls `ble.CloseAdapter()` in its idle branch (no pending retry) before waiting for the next command. This hands the HCI adapter back to BlueZ between command sessions so other BlueZ-based tools (e.g. a second BLE service on the same host) can use the same controller, instead of being locked out until the proxy is restarted.

2. **Configurable connection hold.** The post-command connection hold in `operateConnection()` was hard-coded to 29s. It is now driven by a new `connectionTimeout` environment variable (default 10s), in the same style as `cacheMaxAge` / `scanTimeout`. A shorter value releases the adapter for other tools sooner; a longer value batches follow-up commands.

For the adapter to actually become usable by BlueZ again after release, the HCI User Channel must be brought back up on close — see the companion PR wimaha/ble_BleConnectFix#1 (add HCIDEVUP in `Close()`). After that merges, the `go-ble` replace in `go.mod` can be bumped to include it.

Tested on a Raspberry Pi sharing one adapter between this proxy and a second BLE service: commands succeed, and `btmgmt info` shows the controller returning to BlueZ ~10s after each command.